### PR TITLE
Create STM32L153 Blink Example

### DIFF
--- a/Projects/stm32l153_blink/README.md
+++ b/Projects/stm32l153_blink/README.md
@@ -1,0 +1,37 @@
+# Proyecto Básico STM32L153 (PlatformIO)
+
+Este es un proyecto básico para programar un chip **STM32L153** utilizando PlatformIO y el framework Arduino.
+
+## Configuración de Hardware
+
+El proyecto está configurado para utilizar la definición de placa `nucleo_l152re` como base, ya que el **STM32L153** pertenece a la misma familia (STM32L1) y es compatible a nivel de pines y periféricos básicos.
+
+### Ajustes para tu placa:
+1. **LED:** Por defecto usa `PA5` (LED_BUILTIN de Nucleo). Si tu placa tiene el LED en otro pin (ej. `PC13`), edita `src/main.cpp`.
+2. **Serial:** Usa el puerto Serial por defecto (usualmente TX=PA2, RX=PA3 conectado al programador ST-Link).
+3. **Flash:** El STM32L153 suele tener menos memoria flash (256KB) que el L152RE (512KB). Ten cuidado con programas muy grandes, aunque para este ejemplo básico no hay problema.
+
+## Requisitos
+- **PlatformIO** (CLI o extensión de IDE).
+- **Programador ST-Link** (V2 o V3) para subir el código al chip.
+
+## Cómo compilar y subir
+
+1. **Compilar:**
+   ```bash
+   pio run
+   ```
+
+2. **Subir al microcontrolador:**
+   Conecta tu programador ST-Link a los pines SWDIO, SWCLK, GND y 3.3V del STM32L153.
+   ```bash
+   pio run --target upload
+   ```
+
+## Monitor Serial
+
+Para ver los mensajes de depuración ("LED Encendido", etc.):
+```bash
+pio device monitor
+```
+Asegúrate de que la velocidad esté en 115200 baudios.

--- a/Projects/stm32l153_blink/platformio.ini
+++ b/Projects/stm32l153_blink/platformio.ini
@@ -1,0 +1,13 @@
+[env:nucleo_l152re]
+platform = ststm32
+board = nucleo_l152re
+framework = arduino
+
+; Configuración del monitor serial
+monitor_speed = 115200
+
+; Nota: La placa Nucleo L152RE usa el chip STM32L152RE.
+; El STM32L153 es muy similar (misma familia L1) y este entorno debería funcionar para programas básicos.
+; Si tu chip tiene menos memoria flash (ej. 256KB vs 512KB), tenlo en cuenta al compilar programas grandes.
+; Para subir el código, se asume que usas un programador ST-Link (protocolo por defecto).
+upload_protocol = stlink

--- a/Projects/stm32l153_blink/src/main.cpp
+++ b/Projects/stm32l153_blink/src/main.cpp
@@ -1,0 +1,47 @@
+#include <Arduino.h>
+
+/*
+ * Ejemplo básico para STM32L153 (usando configuración de Nucleo L152RE)
+ * Este programa hace parpadear un LED conectado al pin definido como LED_BUILTIN.
+ *
+ * NOTA IMPORTANTES SOBRE EL HARDWARE:
+ * 1. La placa 'nucleo_l152re' define LED_BUILTIN como PA5 (Pin D13 en formato Arduino).
+ * 2. Si estás usando un chip STM32L153 en una placa personalizada y tu LED está en otro pin
+ *    (por ejemplo, PC13, PB6, etc.), debes cambiar `LED_BUILTIN` por el número de pin correspondiente.
+ *    Ejemplo: #define MI_LED PC13
+ */
+
+// Si necesitas definir un pin específico para tu placa, descomenta y edita la siguiente línea:
+// #define LED_PIN PC13
+// Y usa LED_PIN en lugar de LED_BUILTIN en el código.
+
+#ifndef LED_BUILTIN
+  #define LED_BUILTIN PA5 // Valor por defecto si no está definido
+#endif
+
+void setup() {
+  // Inicializar el pin del LED como salida
+  pinMode(LED_BUILTIN, OUTPUT);
+
+  // Inicializar comunicación serial para depuración (UART por defecto)
+  // En Nucleo L152RE esto suele ser TX=PA2, RX=PA3 conectado al ST-Link VCP
+  Serial.begin(115200);
+  while (!Serial) {
+    ; // Esperar a que el puerto serial se conecte (solo necesario para USB nativo)
+  }
+
+  Serial.println("Iniciando ejemplo Blink en STM32L1...");
+}
+
+void loop() {
+  digitalWrite(LED_BUILTIN, HIGH);  // Encender LED (Voltaje Alto)
+  // Nota: En algunas placas el LED se enciende con LOW. Si es tu caso, invierte HIGH/LOW.
+
+  Serial.println("LED Encendido");
+  delay(1000);                      // Esperar 1000 milisegundos (1 segundo)
+
+  digitalWrite(LED_BUILTIN, LOW);   // Apagar LED (Voltaje Bajo)
+
+  Serial.println("LED Apagado");
+  delay(1000);                      // Esperar 1 segundo
+}


### PR DESCRIPTION
Created a basic PlatformIO project for STM32L153 microcontroller.
- Uses `nucleo_l152re` as a compatible board target.
- Includes `src/main.cpp` with a Blink example.
- Includes `README.md` with instructions in Spanish on how to compile and upload.
- Verified compilation with `pio run`.

---
*PR created automatically by Jules for task [6362082247445359118](https://jules.google.com/task/6362082247445359118) started by @reivajpg*